### PR TITLE
fix a bug

### DIFF
--- a/ICTextView/ICRegularExpression.h
+++ b/ICTextView/ICRegularExpression.h
@@ -66,8 +66,20 @@
 - (id)initWithString:(NSString *)string pattern:(NSString *)pattern options:(NSRegularExpressionOptions)options error:(NSError *__autoreleasing *)error;
 
 - (NSRange)rangeOfCurrentMatch;
+
+/**
+ *  set 'indexOfCurrentMatch' as 0
+ *
+ *  @return the range of first match
+ */
 - (NSRange)rangeOfFirstMatch;
 - (NSRange)rangeOfFirstMatchInRange:(NSRange)range;
+
+/**
+ *  set 'indexOfCurrentMatch' as numberOfMatches - 1
+ *
+ *  @return the range of last match
+ */
 - (NSRange)rangeOfLastMatch;
 - (NSRange)rangeOfLastMatchInRange:(NSRange)range;
 - (NSRange)rangeOfMatchAtIndex:(NSUInteger)index;
@@ -75,4 +87,17 @@
 - (NSRange)rangeOfPreviousMatch;
 - (NSArray *)rangesOfMatchesInRange:(NSRange)range;
 
+/**
+ *  this methed will not change 'indexOfCurrentMatch'
+ *
+ *  @return the range of first match
+ */
+- (NSRange)rangeOfFirstCachedMatch;
+
+/**
+ *  this methed will not change 'indexOfCurrentMatch'
+ *
+ *  @return the range of last match
+ */
+- (NSRange)rangeOfLastCachedMatch;
 @end

--- a/ICTextView/ICRegularExpression.m
+++ b/ICTextView/ICRegularExpression.m
@@ -182,12 +182,20 @@
     return (NSEqualRanges(indexRange, ICRangeNotFound) ? [NSArray array] : [_cachedMatchRanges subarrayWithRange:indexRange]);
 }
 
+- (NSRange)rangeOfFirstCachedMatch{
+    return [[_cachedMatchRanges firstObject] rangeValue];
+}
+
+- (NSRange)rangeOfLastCachedMatch{
+    return [[_cachedMatchRanges lastObject] rangeValue];
+}
+
+#pragma mark - Private methods
+
 - (void)setIndexOfCurrentMatch:(NSUInteger)indexOfCurrentMatch
 {
     _indexOfCurrentMatch = (indexOfCurrentMatch < self.numberOfMatches ? indexOfCurrentMatch : NSNotFound);
 }
-
-#pragma mark - Private methods
 
 - (NSUInteger)indexOfFirstMatchInRange:(NSRange)range
 {

--- a/ICTextView/ICTextView.m
+++ b/ICTextView/ICTextView.m
@@ -196,9 +196,11 @@ static BOOL shouldApplyTextContainerFix = NO;
         return NO;
     
     _searching = YES;
-    
+    NSUInteger index = _searchIndex - _cachedRange.location;
+    NSRange firstRange = [_regex rangeOfFirstCachedMatch];
+    NSRange lastRange = [_regex rangeOfLastCachedMatch];
     // Get match
-    if (_searchIndex == ICSearchIndexAuto)
+    if (_searchIndex == ICSearchIndexAuto || index > lastRange.location || index < firstRange.location)
     {
         if (searchDirection == ICTextViewSearchDirectionForward)
             [_regex rangeOfNextMatch];
@@ -207,7 +209,6 @@ static BOOL shouldApplyTextContainerFix = NO;
     }
     else
     {
-        NSUInteger index = _searchIndex - _cachedRange.location;
         
         if (searchDirection == ICTextViewSearchDirectionForward)
             [_regex rangeOfFirstMatchInRange:NSMakeRange(index, _regex.string.length - index)];


### PR DESCRIPTION
I find a bug that I search something ,and scroll under the last range
matched,and click Next,it will not found,I think it will scroll to  the
first matched range.for example ,input ‘su’ in your demo,it will find
14 matched range,if I scroll to under 14th matched range then click
‘Next’ or scroll to upper 1st matched range then click ’Prev’  it will
return a NotFound,now I fixed it,please test and merge