### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It also features some iOS 7+ specific improvements and bugfixes to the standard 
 
 ### Installation
 
-`ICTextView` can be installed via [Cocoapods](http://cocoapods.org) (just add `pod 'ICTextView'` to your Podfile, then run `pod install`) or as a [Git submodule](http://git-scm.com/book/en/Git-Tools-Submodules).
+`ICTextView` can be installed via [CocoaPods](http://cocoapods.org) (just add `pod 'ICTextView'` to your Podfile, then run `pod install`) or as a [Git submodule](http://git-scm.com/book/en/Git-Tools-Submodules).
 
 Alternatively, you can clone this repo, or even just grab the [ICTextView](ICTextView) folder and put it somewhere in your project.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
